### PR TITLE
Add flexom endpoint

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -22,6 +22,7 @@ const endpoints = {
         'czduc0RZZXdWbjVGbVV4UmlYN1pVSUM3ZFI4YTphSDEzOXZmbzA1ZGdqeDJkSFVSQkFTbmhCRW9h',
     ),
     rexel: new ApiEndpoint('https://ha112-1.overkiz.com/enduser-mobile-web/enduserAPI'),
+    flexom: new ApiEndpoint('https://ha108-1.overkiz.com/enduser-mobile-web/enduserAPI'),
     debug: new ApiEndpoint('https://dev.duboc.pro/api/overkiz'),
 };
 


### PR DESCRIPTION
Hi,
Just adding new endpoint
Flexom is just another rebranding of overkiz for bouygue

I launch `npm run test` and it list my devices
and I also test it locally with homebridge-tahoma plugin that use this library and I can interact with it (after fixing just a bug)